### PR TITLE
allow falsy defaults in `get_json()`, fix priority of default, other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ req.get_json('approved', dtype=bool)
 # make a field optional with default value
 req.get_json('country_code', dtype=str, default="USA", max=3, min=3)
 
+# for ambiguous falsy default value, set required=False
+req.get_json('count', dtype=int, default=0, required=False)
+
 # custom validation with Regular Expressions
 req.get_json('email', match="[^@]+@[^@]+\.[^@]+")
 ```

--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ req.get_json('approved', dtype=bool)
 # make a field optional with default value
 req.get_json('country_code', dtype=str, default="USA", max=3, min=3)
 
-# for ambiguous falsy default value, set required=False
-req.get_json('count', dtype=int, default=0, required=False)
-
 # custom validation with Regular Expressions
 req.get_json('email', match="[^@]+@[^@]+\.[^@]+")
 ```

--- a/falcon_jsonify/__init__.py
+++ b/falcon_jsonify/__init__.py
@@ -25,19 +25,19 @@ class Middleware(object):
         else:
             raise falcon.HTTPBadRequest()
 
-    def get_json(self, field, default=None, **validators):
+    def get_json(self, field, required=True, default=None, **validators):
         """Helper to access JSON fields in the request body
 
         Optional built-in validators.
         """
         value = None
-        if default:
-            value = default
-        elif not field in self.req.json:
+        if field in self.req.json:
+            value = self.req.json[field]
+        elif required and not default:
             self.bad_request("Missing JSON field",
                              "Field '{}' is required".format(field))
         else:
-            value = self.req.json[field]
+            value = default
         return self.validate(field, value, **validators)
 
     def validate(self, field, value, dtype=None, default=None, min=None, max=None, match=None, choices=None):

--- a/falcon_jsonify/__init__.py
+++ b/falcon_jsonify/__init__.py
@@ -25,7 +25,7 @@ class Middleware(object):
         else:
             raise falcon.HTTPBadRequest()
 
-    def get_json(self, field, required=True, default=None, **validators):
+    def get_json(self, field, **kwargs):
         """Helper to access JSON fields in the request body
 
         Optional built-in validators.
@@ -33,11 +33,13 @@ class Middleware(object):
         value = None
         if field in self.req.json:
             value = self.req.json[field]
-        elif required and not default:
+            kwargs.pop('default', None)
+        elif 'default' not in kwargs:
             self.bad_request("Missing JSON field",
                              "Field '{}' is required".format(field))
         else:
-            value = default
+            value = kwargs.pop('default')
+        validators = kwargs
         return self.validate(field, value, **validators)
 
     def validate(self, field, value, dtype=None, default=None, min=None, max=None, match=None, choices=None):

--- a/falcon_jsonify/__init__.py
+++ b/falcon_jsonify/__init__.py
@@ -107,5 +107,5 @@ class Middleware(object):
 
     def process_response(self, req, resp, resource, req_succeeded):
         """Middleware response"""
-        if getattr(resp, "json", None):
+        if getattr(resp, "json", None) is not None:
             resp.body = str.encode(json.dumps(resp.json, cls=DateTimeEncoder))

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Andrei Regiani',
     author_email='andrei.cpp@gmail.com',
     url='https://github.com/AndreiRegiani/falcon-jsonify',
-    version='1.1',
+    version='1.2',
     classifiers=classifiers,
     description='Falcon middleware to serialize/deserialize JSON with built-in input validation',
     # long_description = pypandoc.convert('README.md', 'rst'),


### PR DESCRIPTION
# Problem

- I bumped into use cases in which I wanted to use `get_json()` with a falsy default, e.g.:

- `get_json('comment', default='')`
- `get_json('date', default=None)`

But because of how required/optional fields are implemented, the falsy default was interpreted as "no default passed" and the `Missing JSON field` 400 error was raised. I believe this is not a desired behavior.

- Another issue was that if `default` was passed, it was used independently of whether `field` was present in the request's JSON.

- If the JSON attached to the response was 'falsy', i.e. `request.json = []` or `request.json = {}`, the JSON was not attached to the response body.

# Proposed solution

## Functional changes

✅ The field is now considered as optional **if and only if `default` is passed to `get_json()`**.

To implement this, I changed the function's signature to accept any keyword arguments and then updated the logic to separate the `default` from the `validators` when appropriate.

This allows to accept any default value, including falsy ones such as `""` or `None`, while preserving the previous API.

✅ The default value is now used if and only if the field is not present in the request's JSON.

✅ The `response.json` attribute now gets serialized and attached to the body response if it is falsy (`[]` or `{}`).

## Other changes

- Update version to `1.2`

## Caveats

I would have liked to add tests but none are already present in this package so I don't know how the owner would like to set them up. I'd open an issue for this as I believe it's an impediment for contributing.